### PR TITLE
Add colons to template headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,24 +7,24 @@ assignees: ''
 
 ---
 
-**Describe the problem**
+**Describe the problem:**
 A clear and concise description of what the bug is.
 
-**Steps To Reproduce**
+**Steps To Reproduce:**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+**Expected behavior:**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+**Screenshots:**
 If applicable, add screenshots to help explain your problem.
 
-**Version**
+**Version:**
 Please specify as much version information as possible.
 
-**Additional context**
+**Additional context:**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/build-tool.md
+++ b/.github/ISSUE_TEMPLATE/build-tool.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Describe the Improvement**
+**Describe the Improvement:**
 Provide overview of the requested improvement
 
-**Benefits**
+**Benefits:**
 Describe how this will improve the development process
 
-**Drawbacks**
+**Drawbacks:**
 Think through any consequences (slower build, harder to debug, etc.)
 
-**How to Compare**
+**How to Compare:**
 Provide a benchmark for how this can be compared to the current process

--- a/.github/ISSUE_TEMPLATE/clean-refactor.md
+++ b/.github/ISSUE_TEMPLATE/clean-refactor.md
@@ -7,15 +7,15 @@ assignees: ''
 
 ---
 
-**Describe the Improvement**
+**Describe the Improvement:**
 Explain the goal of this refactor or cleanup task
 
-**Steps**
+**Steps:**
 As best you can, detail the steps to make this change:
   1.    
 
-**Additional Context and Links**
+**Additional Context and Links:**
 Provide any discussion or links to documents/webpages that help explain why this change is important
 
-**Testing**
+**Testing:**
 How can we verify that this change doesn't break anything

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,17 +7,17 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe**
+**Is your feature request related to a problem? Please describe:**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution**
+**Describe the solution:**
 A clear and concise description of what you want to happen and/or how it should solve the problem.
 
-**Describe alternatives you've considered**
+**Describe alternatives you've considered:**
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Links/Additional context**
+**Links/Additional context:**
 Add any other context, links, or screenshots about the feature request here.
 
-**Testing**
+**Testing:**
 Provide any functional requirements for this new feature to help with testing.

--- a/.github/ISSUE_TEMPLATE/update_documentation.md
+++ b/.github/ISSUE_TEMPLATE/update_documentation.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-**Describe the change**
+**Describe the change:**
 What needs to be updated/is confusing
 
-**Additional context/Links**
+**Additional context/Links:**
 Add any other context to discussion or links that help explain the the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
-# Description
+# Description:
 _Quickly describe what you are solving and how_
 
-# Related
+# Related:
 _Links to any Github issues or documentation used for this change_
 
-# Visual
+# Visual:
 _Add a screenshot!_
 
-# TODO
+# TODO:
  - [ ] Complete PR Body
  - [ ] Updated Architecture/README documents


### PR DESCRIPTION
# Description
Add colons so issues/PRs will have break before paragraph/after header if not being rendered with bold

# Related
- closes #10

# TODO
 - [x] Complete PR Body
 - [x] Updated Architecture/README documents
