### PR TITLE
Feature(Workflows): Auto Label Action `WIP` labels and Verify PR Merge Action 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,3 +17,14 @@ This directory contains files related to Github configurations and actions:
     - Adds Labels to PRs based on branch name
     - `pr-branch-labeler.yml` and `workflows/auto-label.yaml`
 
+  **Verify Merge Action**
+
+    - _This is a required action before PRs can be merged_
+    - Runs the verify-merge script in `scripts/` directory and fails the action if the script does not complete succesfully
+      - Prevents mergin branches with name `poc` or where last commit contains `wip` 
+
+
+## Ideas
+  - [ ] pr mutation testing: https://github.com/tylermurry/github-pr-landmine
+  - [ ] build artifact/docs on merge to master
+  - [ ] run build/compile in verify-merge to ensure PR is valid

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,7 @@ This directory contains files related to Github configurations and actions:
   ### Verify Merge Action
 
   - _This is a required action before PRs can be merged_
+  - **NOTE:** If you commit to a PR with `wip` commit message, an email will be sent when this action fails
   - Runs the verify-merge script in `scripts/` directory and fails the action if the script does not complete succesfully
     - Prevents mergin branches with name `poc` or where last commit contains `wip` 
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,17 +7,18 @@ This directory contains files related to Github configurations and actions:
   - Action Files and Configurations
 
 ## Actions
-  **Manage Label Action**
+
+  ### Manage Label Action
 
     - Creates/Deletes any labels not defined in configuration
     - `labels.yaml` and `workflows/manage-labels.yaml`
 
-  **Auto Label Action**
+  ### Auto Label Action
 
     - Adds Labels to PRs based on branch name
     - `pr-branch-labeler.yml` and `workflows/auto-label.yaml`
 
-  **Verify Merge Action**
+  ### Verify Merge Action
 
     - _This is a required action before PRs can be merged_
     - Runs the verify-merge script in `scripts/` directory and fails the action if the script does not complete succesfully

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,19 +10,19 @@ This directory contains files related to Github configurations and actions:
 
   ### Manage Label Action
 
-    - Creates/Deletes any labels not defined in configuration
-    - `labels.yaml` and `workflows/manage-labels.yaml`
+  - Creates/Deletes any labels not defined in configuration
+  - `labels.yaml` and `workflows/manage-labels.yaml`
 
   ### Auto Label Action
 
-    - Adds Labels to PRs based on branch name
-    - `pr-branch-labeler.yml` and `workflows/auto-label.yaml`
+  - Adds Labels to PRs based on branch name
+  - `pr-branch-labeler.yml` and `workflows/auto-label.yaml`
 
   ### Verify Merge Action
 
-    - _This is a required action before PRs can be merged_
-    - Runs the verify-merge script in `scripts/` directory and fails the action if the script does not complete succesfully
-      - Prevents mergin branches with name `poc` or where last commit contains `wip` 
+  - _This is a required action before PRs can be merged_
+  - Runs the verify-merge script in `scripts/` directory and fails the action if the script does not complete succesfully
+    - Prevents mergin branches with name `poc` or where last commit contains `wip` 
 
 
 ## Ideas

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -6,6 +6,7 @@ on:
     types: 
       - opened
       - closed
+      - synchronize
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -19,14 +20,38 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+
     - name: Remove Label
       if: github.event.action == 'closed'
       uses: actions-ecosystem/action-remove-labels@v1
       with:
           github_token: ${{ secrets.github_token }}
-          labels: 
-            - "status: wip"
-            - "status: blocked"
+          labels: |
+            "status: wip"
+            "status: blocked"
+
+
+    - uses: actions/checkout@v2 
+      if: github.event.action == 'synchronize'
+
+    - name: Get Commit Message
+      if: github.event.action == 'synchronize'
+      id: commit
+      run: |
+        git fetch
+        git checkout ${{ github.event.pull_request.head.ref }}
+        echo "::set-output name=msg::$(git log -1 --pretty=format:'%s')"
+
+    - name: Display commit message
+      if: github.event.action == 'synchronize'
+      run: echo ${{ steps.commit.outputs.msg }}
+
+    - if: startsWith(steps.commit.outputs.msg, 'wip') && github.event.action == 'synchronize'
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        github_token: ${{ secrets.github_token }} 
+        labels: "status: wip"
+
 
     # TODO: check commit message for wip
     # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -2,8 +2,7 @@
 name: Auto Label PR
 
 on: pull_request
-  types:
-    - opened
+  types: opened
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -24,7 +24,9 @@ jobs:
       uses: actions-ecosystem/action-remove-labels@v1
       with:
           github_token: ${{ secrets.github_token }}
-          labels: "status: wip"
+          labels: 
+            - "status: wip"
+            - "status: blocked"
 
     # TODO: check commit message for wip
     # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,8 +1,9 @@
 # Name should reflect when action occurs
 name: Auto Label PR
 
-on: pull_request
-  types: opened
+on: 
+  pull_request:
+    types: opened
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -3,7 +3,9 @@ name: Auto Label PR
 
 on: 
   pull_request:
-    types: opened
+    types: 
+      - opened
+      - closed
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -16,6 +18,13 @@ jobs:
       uses: ffittschen/pr-branch-labeler@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Remove Label
+      if: github.event.action == 'closed'
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+          github_token: ${{ secrets.github_token }}
+          labels: "status: wip"
 
     # TODO: check commit message for wip
     # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -15,3 +15,8 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+    # TODO: check commit message for wip
+    # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2
+    # - name: Get Branch Name
+    # 
+

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -13,6 +13,8 @@ jobs:
   auto-labels:
     runs-on: ubuntu-latest
 
+    ## Label PR on PR open based on branch name
+
     steps:
     - name: Label PR
       if: github.event.action == 'opened' # Only run the action when the PR was first opened
@@ -20,6 +22,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+    ## Remove labels on PR close
 
     - name: Remove Label
       if: github.event.action == 'closed'
@@ -30,6 +33,8 @@ jobs:
             "status: wip"
             "status: blocked"
 
+    ## Actions to run when commit added to PR
+    # - Check if commit message has 'wip' and label if so
 
     - uses: actions/checkout@v2 
       if: github.event.action == 'synchronize'
@@ -41,10 +46,6 @@ jobs:
         git fetch
         git checkout ${{ github.event.pull_request.head.ref }}
         echo "::set-output name=msg::$(git log -1 --pretty=format:'%s')"
-
-    - name: Display commit message
-      if: github.event.action == 'synchronize'
-      run: echo ${{ steps.commit.outputs.msg }}
 
     - if: startsWith(steps.commit.outputs.msg, 'wip') && github.event.action == 'synchronize'
       uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -2,6 +2,8 @@
 name: Auto Label PR
 
 on: pull_request
+  types:
+    - opened
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -53,9 +53,3 @@ jobs:
         github_token: ${{ secrets.github_token }} 
         labels: "status: wip"
 
-
-    # TODO: check commit message for wip
-    # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2
-    # - name: Get Branch Name
-    # 
-

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -17,7 +17,7 @@ jobs:
         /bin/bash scripts/actions/verify-merge.sh
         exit $?
       env:
-        BRANCH: ${{ github.base_ref }}
+        BRANCH: ${{ github.event.pull_request.head.ref }}
 
     # TODO:
     # - Prevent poc branch

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -12,6 +12,10 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    - name: No POC
+      run: /bin/bash scripts/actions/verify-merge.sh
+      env:
+        BRANCH: ${{ github.base_ref }}
 
     # TODO:
     # - Prevent poc branch

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -14,18 +14,8 @@ jobs:
 
     - name: Prevent POC/WIP branches
       run: |
-        echo $PR_NUM
         /bin/bash scripts/workflows/verify-merge.sh
         exit $?
       env:
         BRANCH: ${{ github.event.pull_request.head.ref }}
-        PR_NUM: ${{ toJson(github.event.pull_request.labels.*.name) }}
-
-
-    # TODO:
-    # - Prevent labeled:
-    #    - `status: wip`
-    #    - `status: blocked`?
-    #    - https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
-    #       - get `number` from action.event and then get labels
 

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -1,0 +1,35 @@
+# Name should reflect when action occurs
+name: Check if PR can Merge
+
+on: pull_request
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  auto-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+
+    # TODO:
+    # - Prevent poc branch
+    #    - get branch name, check against regexp, fail action if doesnt match
+    #    - https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
+    # - Prevent labeled:
+    #    - `status: wip`
+    #    - `status: blocked`?
+    #    - https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
+    #       - get `number` from action.event and then get labels
+    # - Prevent if merge branch has failing build action? 
+    #    - https://github.com/cirruslabs/gh-submit-queue
+    # - Last commit message has `wip` in it? 
+    #    - https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2
+
+    # - name: Label PR
+    #  if: github.event.action == 'opened' # Only run the action when the PR was first opened
+    #  uses: ffittschen/pr-branch-labeler@v1
+    #  with:
+    #    repo-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -14,18 +14,13 @@ jobs:
 
     - name: Prevent POC/WIP branches
       run: |
-        git fetch
-        git checkout $BRANCH
-        /bin/bash scripts/actions/verify-merge.sh
+        /bin/bash scripts/workflows/verify-merge.sh
         exit $?
       env:
         BRANCH: ${{ github.event.pull_request.head.ref }}
 
 
     # TODO:
-    # - Prevent poc branch
-    #    - get branch name, check against regexp, fail action if doesnt match
-    #    - https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
     # - Prevent labeled:
     #    - `status: wip`
     #    - `status: blocked`?
@@ -33,8 +28,6 @@ jobs:
     #       - get `number` from action.event and then get labels
     # - Prevent if merge branch has failing build action? 
     #    - https://github.com/cirruslabs/gh-submit-queue
-    # - Last commit message has `wip` in it? 
-    #    - https://github.community/t/accessing-commit-message-in-pull-request-event/17158/2
 
     # - name: Label PR
     #  if: github.event.action == 'opened' # Only run the action when the PR was first opened

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -12,12 +12,15 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: No POC
+    - name: Prevent POC/WIP branches
       run: |
+        git fetch
+        git checkout $BRANCH
         /bin/bash scripts/actions/verify-merge.sh
         exit $?
       env:
         BRANCH: ${{ github.event.pull_request.head.ref }}
+
 
     # TODO:
     # - Prevent poc branch

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -13,7 +13,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: No POC
-      run: /bin/bash scripts/actions/verify-merge.sh
+      run: |
+        /bin/bash scripts/actions/verify-merge.sh
+        exit $?
       env:
         BRANCH: ${{ github.base_ref }}
 

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -5,7 +5,7 @@ on: pull_request
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  auto-labels:
+  verify-merge:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -14,10 +14,12 @@ jobs:
 
     - name: Prevent POC/WIP branches
       run: |
+        echo $PR_NUM
         /bin/bash scripts/workflows/verify-merge.sh
         exit $?
       env:
         BRANCH: ${{ github.event.pull_request.head.ref }}
+        PR_NUM: ${{ toJson(github.event.pull_request) }}
 
 
     # TODO:
@@ -26,12 +28,4 @@ jobs:
     #    - `status: blocked`?
     #    - https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
     #       - get `number` from action.event and then get labels
-    # - Prevent if merge branch has failing build action? 
-    #    - https://github.com/cirruslabs/gh-submit-queue
-
-    # - name: Label PR
-    #  if: github.event.action == 'opened' # Only run the action when the PR was first opened
-    #  uses: ffittschen/pr-branch-labeler@v1
-    #  with:
-    #    repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/verify-merge.yaml
+++ b/.github/workflows/verify-merge.yaml
@@ -19,7 +19,7 @@ jobs:
         exit $?
       env:
         BRANCH: ${{ github.event.pull_request.head.ref }}
-        PR_NUM: ${{ toJson(github.event.pull_request) }}
+        PR_NUM: ${{ toJson(github.event.pull_request.labels.*.name) }}
 
 
     # TODO:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Git Hooks are scripts that can be run during certain parts of the Git process (a
 
 To create a hook, you add a script file (or symbolic link to one) in the `.git/hooks/` directory with the name of the hook from [this list](https://git-scm.com/docs/githooks#_hooks). (e.g. to run a script before a commit is saved -- to verify the contents of the commit, verify the app builds, etc -- you would create `./.git/hooks/pre-commit`).
 
-There are a few examples of Git hooks in this project to enforce branch name conventions and commit message style, please review the documentation in the `scripts/hooks/` directory to understand how they work and use them in your project.
+[Review Hooks in this Repo](./scripts/hooks/)
 
 #### Workflows
 [GitHub Workflows/Actions](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) are commands that can be run on GitHub servers, these are added in `.github/workflows` and defined with YAML files that express when the workflow should run and the steps it should take. Github can enforce that these workflows are successful before Pull Requests are merged via the [Branch Settings Page](../../settings/branches), it can also trigger them after users perform certain actions or they can be manually triggered to run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ To create a hook, you add a script file (or symbolic link to one) in the `.git/h
 [Review Workflows in this Repo](./.github/workflows#github-workflows)
 
 
-#### Scripts
+#### Other Scripts
 Shell scripts are short programs that are created to help with small tasks. They can be a part of a workflow or hook, or they can help with  deployment/installation and running the final software product.  
 
 [Review Scripts in this Repo](./scripts/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,13 @@ Break down how each folder is used in the repo and how different code file types
 |-- workflows/
 |---- (Github workflow .yaml files)
 |-- (other github specific files)
+- img/
+|-- (project image files)
+- scripts/
+|-- hooks/
+|---- (Git Hooks Scripts)
+|-- workflows/
+|---- (Github workflow Scripts)
 - (project config files and READMEs)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,18 +90,15 @@ To create a hook, you add a script file (or symbolic link to one) in the `.git/h
 There are a few examples of Git hooks in this project to enforce branch name conventions and commit message style, please review the documentation in the `scripts/hooks/` directory to understand how they work and use them in your project.
 
 #### Workflows
-[GitHub Workflows/Actions](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) are commands that can be run on GitHub servers, these are added in `.github/workflows` and defined with YAML files that express when the workflow should run and the steps it should take. 
+[GitHub Workflows/Actions](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) are commands that can be run on GitHub servers, these are added in `.github/workflows` and defined with YAML files that express when the workflow should run and the steps it should take. Github can enforce that these workflows are successful before Pull Requests are merged via the [Branch Settings Page](../../settings/branches), it can also trigger them after users perform certain actions or they can be manually triggered to run.
 
-Github can enforce that these workflows are successful before Pull Requests are merged via the [Branch Settings Page](../../settings/branches), it can also trigger them after users perform certain actions or they can be manually triggered to run.
-
-**[Label Manager](./.github/workflows/manage-labels.yml)**  
-This project defines the Github Labels in a [YAML file](./.github/labels.yaml) that is managed by the [Github Labeler Action](https://github.com/marketplace/actions/github-labeler). 
-Any labels that are not defined in this file will be removed every time this action is run. **This does not affect PRs**
+[Review Workflows in this Repo](./.github/workflows/)
 
 
-#### Shell scripts
-Shell scripts can be created to help with deployment/installation or running the software.  
+#### Scripts
+Shell scripts are short programs that are created to help with small tasks. They can be a part of a workflow or hook, or they can help with  deployment/installation and running the final software product.  
 
+[Review Scripts in this Repo](./scripts/)
 
 
 ### Branching and Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,12 +87,12 @@ Git Hooks are scripts that can be run during certain parts of the Git process (a
 
 To create a hook, you add a script file (or symbolic link to one) in the `.git/hooks/` directory with the name of the hook from [this list](https://git-scm.com/docs/githooks#_hooks). (e.g. to run a script before a commit is saved -- to verify the contents of the commit, verify the app builds, etc -- you would create `./.git/hooks/pre-commit`).
 
-[Review Hooks in this Repo](./scripts/hooks/)
+[Review Hooks in this Repo](./scripts/hooks#git-hook-scripts)
 
 #### Workflows
 [GitHub Workflows/Actions](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) are commands that can be run on GitHub servers, these are added in `.github/workflows` and defined with YAML files that express when the workflow should run and the steps it should take. Github can enforce that these workflows are successful before Pull Requests are merged via the [Branch Settings Page](../../settings/branches), it can also trigger them after users perform certain actions or they can be manually triggered to run.
 
-[Review Workflows in this Repo](./.github/workflows/)
+[Review Workflows in this Repo](./.github/workflows#github-workflows)
 
 
 #### Scripts

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ _This section should try to quickly explain how to setup the project and start u
  - [ ] (Optional) Modify [Pull Request Template]
  - [ ] (Optional) Update [Github Workflows]
     - [ ] Review and Update [Label Definitions] for Label Manager
+    - [ ] Review Auto PR Labeler action [Branch-Label Mappings]
+    - [ ] Review [PR Merge Verify] and the [script](scripts/workflows/verify-merge.sh) it calls
  - [ ] (Optional) Enable [Git Hooks] and set [Commit Message Template]
  - [ ] Add Project Build and Configuration Files
  - Start Coding!
@@ -70,6 +72,8 @@ _This section should try to quickly explain how to setup the project and start u
 [Pull Request Template]: .github/pull_request_template.md
 [Github Workflows]: .github/workflows#github-workflows
 [Label Definitions]: .github/labels.yaml
+[Branch-Label Mappings]: .github/pr-branch-labeler.yml
+[PR Merge Verify]: .github/workflows/verify-merge.yaml
 [Git Hooks]: scripts/hooks#git-hook-scripts
 [Commit Message Template]: .gitmessage
 [Code of Conduct]: CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _This section should try to quickly explain how to setup the project and start u
  - [ ] (Optional) Update [Github Workflows]
     - [ ] Review and Update [Label Definitions] for Label Manager
     - [ ] Review Auto PR Labeler action [Branch-Label Mappings]
-    - [ ] Review [PR Merge Verify] and the [script](scripts/workflows/verify-merge.sh) it calls
+    - [ ] Review [PR Merge Verify] and the [script](scripts/workflows/verify-merge.sh) the workflow uses
  - [ ] (Optional) Enable [Git Hooks] and set [Commit Message Template]
  - [ ] Add Project Build and Configuration Files
  - Start Coding!

--- a/scripts/actions/verify-merge.sh
+++ b/scripts/actions/verify-merge.sh
@@ -5,3 +5,9 @@ echo "$BRANCH"
 if [[ "$BRANCH" =~ "poc/" ]]; then
   exit -1 
 fi;
+
+MSG=`git log $BRANCH -1 --pretty=format:"%s"`
+echo "$MSG"
+if [[ "$MSG" =~ wip* ]]; then
+  exit -1
+fi

--- a/scripts/actions/verify-merge.sh
+++ b/scripts/actions/verify-merge.sh
@@ -3,11 +3,13 @@
 
 echo "$BRANCH"
 if [[ "$BRANCH" =~ "poc/" ]]; then
+  echo "Not allowed to merge POC branch"
   exit -1 
 fi;
 
 MSG=`git log $BRANCH -1 --pretty=format:"%s"`
 echo "$MSG"
-if [[ "$MSG" =~ wip* ]]; then
+if [[ "$MSG" = wip* ]]; then
+  echo "Not allowed to merge when last commit message starts with 'wip'"
   exit -1
 fi

--- a/scripts/actions/verify-merge.sh
+++ b/scripts/actions/verify-merge.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
+# Verify that a branch can be merged
 
 echo "$BRANCH"
-if [[ "$BRANCH" ~= "poc.*:" ]]; then
+if [[ "$BRANCH" =~ "poc.*:" ]]; then
   exit -1 
 fi;

--- a/scripts/actions/verify-merge.sh
+++ b/scripts/actions/verify-merge.sh
@@ -2,6 +2,6 @@
 # Verify that a branch can be merged
 
 echo "$BRANCH"
-if [[ "$BRANCH" =~ "poc.*:" ]]; then
+if [[ "$BRANCH" =~ "poc/" ]]; then
   exit -1 
 fi;

--- a/scripts/actions/verify-merge.sh
+++ b/scripts/actions/verify-merge.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+echo "$BRANCH"
+if [[ "$BRANCH" ~= "poc.*:" ]]; then
+  exit -1 
+fi;

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -2,7 +2,7 @@
 
 Git Hooks are run by Git during specific actions. Follow the instructions below to enable:
 
-## To Add to Workflow
+## To Add to Git Hook
 
 Git hooks need to be added to your local repo for each project,
 - Create Symbolic links in `.git/hooks/` for git hook scripts you want to use

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -29,5 +29,10 @@ Git hooks need to be added to your local repo for each project,
  - Run tests before commit
    - only if code files touched?
    - only run tests affected by code files modified?
+ - Prevent Commit based on Github Branch protections
+   - requires reading from github API
+     - https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-branch-protection
+     - use curl and `-u` flag to retrieve branches protected
+     - add to config file that hook reads? `./.github/config.yml` `prevent_push: ["<branch_name>"]`
  - Server side hooks
    - on receive, deploy newest changes

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -2,7 +2,7 @@
 
 Git Hooks are run by Git during specific actions. Follow the instructions below to enable:
 
-## To Add to Git Hook
+## Add Git Hooks
 
 Git hooks need to be added to your local repo for each project,
 - Create Symbolic links in `.git/hooks/` for git hook scripts you want to use

--- a/scripts/workflows/README.md
+++ b/scripts/workflows/README.md
@@ -1,6 +1,6 @@
 # Github Workflow Scripts
 These scripts are run as a part of Github Workflows, these are custom scripts that are meant to do specific tasks during each action.
 
-- Verify Merge
+## Verify Merge
   - Prevents Branches with `poc` prefix from merging
   - Prevents Branches where last commit starts with `wip` from merging

--- a/scripts/workflows/README.md
+++ b/scripts/workflows/README.md
@@ -1,0 +1,6 @@
+# Github Workflow Scripts
+These scripts are run as a part of Github Workflows, these are custom scripts that are meant to do specific tasks during each action.
+
+- Verify Merge
+  - Prevents Branches with `poc` prefix from merging
+  - Prevents Branches where last commit starts with `wip` from merging

--- a/scripts/workflows/verify-merge.sh
+++ b/scripts/workflows/verify-merge.sh
@@ -1,14 +1,19 @@
 #! /bin/bash
 # Verify that a branch can be merged
 
-echo "$BRANCH"
+# check branch type prefix != "poc"
+
 if [[ "$BRANCH" =~ "poc/" ]]; then
   echo "Not allowed to merge POC branch"
   exit -1 
 fi;
 
+# need to do fetch because action just checks out sparse version of repo
+git fetch
+
+# get message and verify doesn't start with "wip"
+
 MSG=`git log $BRANCH -1 --pretty=format:"%s"`
-echo "$MSG"
 if [[ "$MSG" = wip* ]]; then
   echo "Not allowed to merge when last commit message starts with 'wip'"
   exit -1

--- a/scripts/workflows/verify-merge.sh
+++ b/scripts/workflows/verify-merge.sh
@@ -8,8 +8,9 @@ if [[ "$BRANCH" =~ "poc/" ]]; then
   exit -1 
 fi;
 
-# need to do fetch because action just checks out sparse version of repo
+# need to do fetch/checkout because action just checks out sparse version of repo
 git fetch
+git checkout $BRANCH
 
 # get message and verify doesn't start with "wip"
 


### PR DESCRIPTION
# Description:
More GitHub Actions:
 - Verify Merge Action
    - Runs Verify Merge script
    - checks no `wip` last commit
    - checks branch name prefix not `poc`
 - Update Auto Label Action
    - Remove `status: wip` or `status: blocked` labels on PR close/merge
    - if last commit status contains `wip`, add `status: wip` label
Updated READMEs

# Related:
#5

# Visual:
<img width="979" alt="Screen Shot 2020-11-22 at 9 24 39 PM" src="https://user-images.githubusercontent.com/1504590/99931385-2abe4400-2d09-11eb-9c3f-8489bd8ccb5f.png">


# TODO:
 - [x] Verify PR Merge Action to prevent PRs we dont want
 - [x] Add Auto Label Action for `WIP` based on commit message
 - [x] Remove `wip` or `blocked` label on merge/close
 - [x] Updated Architecture/README documents
   - Update README in `.github/workflows`
      - Explain process/restrictions these workflows enforce
      - Email when use `wip:` commit message
      - more ideas:
         - pr mutation testing: https://github.com/tylermurry/github-pr-landmine
         - build artifact/docs on merge to master
         - build in verify-merge
   - Add README in `.scripts/workflows`
       - Explain what scripts are for
   - Main README
       - Links/Notes on Actions
   - CONTRIBUTING
       - Clean up sections for hooks/workflows to add links to READMEs
       - rename shell scripts to "deploy" scripts 
       - create OR reference to section on bin/ directory (executable)
 - [x] Complete PR Body
