### PR TITLE
Fix: Change Warning Limits to 25 files and 400 lines and fix closing PR remove label

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -30,7 +30,7 @@ jobs:
       with:
           github_token: ${{ secrets.github_token }}
           labels: |
-            "status: wip"
+            "status: WIP"
             "status: blocked"
 
     ## Actions to run when commit added to PR

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -21,6 +21,8 @@ Git hooks need to be added to your local repo for each project,
 
   5. `ln -s ../../scripts/hooks/post-commit.sh post-commit`
      - warns when changes are getting large since "last merge"
+        - 25 files
+        - 400 lines
 
 
 ## Ideas for Hooks

--- a/scripts/hooks/post-commit.sh
+++ b/scripts/hooks/post-commit.sh
@@ -20,8 +20,8 @@ else
 fi
 
 
-FILE_LIMIT=10
-LINE_LIMIT=1000
+FILE_LIMIT=25
+LINE_LIMIT=400
 
 FILE_LIMIT_WARNING=" ! warning: more than $FILE_LIMIT files changed since $DIFF_COMMIT "
 LINE_LIMIT_WARNING=" ! warning: more than $LINE_LIMIT files changed since $DIFF_COMMIT "


### PR DESCRIPTION
# Description:
After some bigger PRs at work, I decided to change the warning limits for files and lines to 25 files and 400 lines before we start to warn the developer

# TODO:
 - [x] Complete PR Body
 - [x] Updated Architecture/README documents
