### PR TITLE
fix(workflows): Auto Label Workflow fails on PR Close

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Remove Label
       if: github.event.action == 'closed'
-      uses: actions-ecosystem/action-remove-labels@v1
+      uses: devlinjunker/action-remove-labels@v1
       with:
           github_token: ${{ secrets.github_token }}
           labels: |


### PR DESCRIPTION
# Description:
Auto Label Action fails when PR is closed due to missing labels. 

Attempting to test with my own version of the action... but I think I might need to make it public or compile or something
 - probably this: https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/publishing-actions-in-github-marketplace#publishing-an-action


# Related:
- failure on PR close: https://github.com/devlinjunker/template.github/actions/runs/390723230
- Issue that indicates this is issue with action: https://github.com/actions-ecosystem/action-remove-labels/issues/122
- New Action to Test: https://github.com/devlinjunker/action-remove-labels/releases/tag/v1.0.3


# Visual:
N/A

# TODO:
 - [x] Complete PR Body
 - ~~[ ] Updated Architecture/README documents~~
