### PR TITLE
Test: Testing Remove Label Fix

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Remove Label
       if: github.event.action == 'closed'
-      uses: actions-ecosystem/action-remove-labels@v1
+      uses: devlinjunker/action-remove-labels@v1
       with:
           github_token: ${{ secrets.github_token }}
           labels: |


### PR DESCRIPTION
# Description:
Remove Label Action is still not working due to 'Label does not exist' error, according to [this issue on github](https://github.com/actions/stale/issues/173) it may be due to the colon (`:`) in the label name, and workaround is to use `encodeURIComponent()`. Testing this....

# Related:
- Previous Attempt PR: #33 
- Release of Test Action: https://github.com/devlinjunker/action-remove-labels/releases/tag/v1.0.4

# TODO:
 - [x] Complete PR Body
 - [x] Updated Architecture/README documents
