### PR TITLE
Fix: Commit Message Regexp

### DIFF
--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -23,7 +23,7 @@ main() {
   # create regexp for first line of commit message -- [square brackets] are optional:      <prefix>[(scope)][!]:<description>
     # scope provides more details
     # ! indicates BREAKING CHANGES
-  regexp="^($(echo "${MSG_PREFIXES[@]} ${OTHER_PREFIXES[@]}" | sed "s/ /|/g"))(\([a-zA-Z0-9 ]*\))?\!?\:[A-Za-z0-9\._\-\s]*"
+  regexp="^($(echo "${MSG_PREFIXES[@]} ${OTHER_PREFIXES[@]}" | sed "s/ /|/g"))(\([a-zA-Z0-9 \-]*\))?\!?\:[A-Za-z0-9\._\-\s]*"
 
   # check that first line of message matches regexp
   if [[ ! $FIRST_LINE =~ $regexp ]]; then


### PR DESCRIPTION
# Description:
Commit message regexp would not allow `-` in the optional scope section


# Visual:
<img width="1023" alt="Screen Shot 2020-12-13 at 3 21 13 PM" src="https://user-images.githubusercontent.com/1504590/102027080-da119800-3d56-11eb-9a60-f04f2e92a31f.png">

# TODO:
 - [x] Complete PR Body
 - ~[ ] Updated Architecture/README documents~
