### PR TITLE
Fix: Add release label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,5 +1,8 @@
 ## Tags
 
+- name: "- release -"
+  color: "f91351";
+  description: "Tag for each Release PR"
 - name: "-priority"
   color: "d93f0b" # red
   description: "Take a look at this soon!"

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -57,7 +57,7 @@ jobs:
         destination_branch: "main" 
         pr_title: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
         pr_body: ${{ steps.version.outputs.changelog }}
-        # pr_label: release
+        pr_label: "- release -"
 
     # Note: This increments minor version only, for now major releases will be done manually
     # until we figure out a better method


### PR DESCRIPTION
# Description:
Add `- release -` label for release PRs

# Visual:
N/A

# TODO:
 - [x] Complete PR Body
 - ~[ ] Updated Architecture/README documents~
